### PR TITLE
ルーティング機能の追加

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <title>React App</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,9 @@
-import Home from './pages/Home';
+import { useRoutes } from 'react-router-dom';
+import { appRoutes } from './router/routes';
 
 const App = () => {
-  return <Home />;
+  const routing = useRoutes(appRoutes);
+  return routing;
 };
 
 export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,17 @@
 import { useRoutes } from 'react-router-dom';
 import { appRoutes } from './router/routes';
+import Maintenance from './pages/common/Maintenance';
+
+// メンテナンス中はこの値を true に変更する
+const isMaintenance = false;
 
 const App = () => {
   const routing = useRoutes(appRoutes);
+
+  if (isMaintenance) {
+    return <Maintenance />;
+  }
+
   return routing;
 };
 

--- a/src/app/hooks.ts
+++ b/src/app/hooks.ts
@@ -1,6 +1,5 @@
-import { useDispatch, useSelector } from 'react-redux';
-import type { TypedUseSelectorHook } from 'react-redux';
-import type { RootState, AppDispatch } from './store';
+import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
+import { RootState, AppDispatch } from './store';
 
 export const useAppDispatch: () => AppDispatch = useDispatch;
 export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 import mapboxgl from 'mapbox-gl';
-import type { Place } from '../features/places/placesSlice';
+import { Place } from '../features/places/placesSlice';
 
 mapboxgl.accessToken = import.meta.env.VITE_MAPBOX_ACCESS_TOKEN!;
 

--- a/src/features/places/placeAPI.ts
+++ b/src/features/places/placeAPI.ts
@@ -1,5 +1,5 @@
 import apiClient from '../../api/client';
-import type { Place } from './placesSlice';
+import { Place } from './placesSlice';
 
 export async function fetchPlaces(): Promise<Place[]> {
   const response = await apiClient.get('/places');

--- a/src/features/places/placesSlice.ts
+++ b/src/features/places/placesSlice.ts
@@ -1,5 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit';
-import type { PayloadAction } from '@reduxjs/toolkit';
+import { PayloadAction } from '@reduxjs/toolkit';
 
 export interface Place {
   id: string;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,11 +3,14 @@ import ReactDOM from 'react-dom/client';
 import App from './App';
 import { Provider } from 'react-redux';
 import { store } from './app/store';
+import { BrowserRouter } from 'react-router-dom';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <Provider store={store}>
-      <App />
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
     </Provider>
   </React.StrictMode>
 );

--- a/src/pages/common/Maintenance.tsx
+++ b/src/pages/common/Maintenance.tsx
@@ -1,0 +1,10 @@
+const Maintenance = () => {
+  return (
+    <div style={{ padding: "2rem", textAlign: "center" }}>
+      <h1>現在メンテナンス中です</h1>
+      <p>しばらくしてから再度アクセスしてください。</p>
+    </div>
+  );
+};
+
+export default Maintenance;

--- a/src/pages/common/NotFound.tsx
+++ b/src/pages/common/NotFound.tsx
@@ -1,0 +1,10 @@
+const NotFound = () => {
+  return (
+    <div style={{ padding: "2rem", textAlign: "center" }}>
+      <h1>404 - ページが見つかりません</h1>
+      <p>お探しのページは存在しないか、URLが間違っています。</p>
+    </div>
+  );
+};
+
+export default NotFound;

--- a/src/pages/signup/Complete.tsx
+++ b/src/pages/signup/Complete.tsx
@@ -1,0 +1,5 @@
+const SignupComplete = () => {
+  return <div>会員登録 完了ページ</div>;
+};
+
+export default SignupComplete;

--- a/src/pages/signup/Confirm.tsx
+++ b/src/pages/signup/Confirm.tsx
@@ -1,0 +1,5 @@
+const SignupConfirm = () => {
+  return <div>会員情報確認ページ</div>;
+}
+
+export default SignupConfirm;

--- a/src/pages/signup/Input.tsx
+++ b/src/pages/signup/Input.tsx
@@ -1,0 +1,5 @@
+const SignupInput = () => {
+  return <div>会員登録 入力ページ</div>;
+};
+
+export default SignupInput;

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -1,0 +1,6 @@
+import { RouteObject } from 'react-router-dom';
+import { signupRoutes } from './signup';
+
+export const appRoutes: RouteObject[] = [
+  ...signupRoutes,
+];

--- a/src/router/routes.tsx
+++ b/src/router/routes.tsx
@@ -1,6 +1,12 @@
 import { RouteObject } from 'react-router-dom';
 import { signupRoutes } from './signup';
+import NotFound from '../pages/common/NotFound';
 
 export const appRoutes: RouteObject[] = [
   ...signupRoutes,
+
+  {
+    path: '*',
+    element: <NotFound />,
+  },
 ];

--- a/src/router/signup.tsx
+++ b/src/router/signup.tsx
@@ -1,0 +1,18 @@
+import SignupInput from '../pages/signup/Input.tsx';
+import SignupConfirm from '../pages/signup/Confirm.tsx';
+import SignupComplete from '../pages/signup/Complete.tsx';
+
+export const signupRoutes = [
+  {
+    path: '/signup/input',
+    element: <SignupInput />,
+  },
+  {
+    path: '/signup/confirm',
+    element: <SignupConfirm />,
+  },
+  {
+    path: '/signup/complete',
+    element: <SignupComplete />,
+  },
+];

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -10,7 +10,7 @@
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
-    "verbatimModuleSyntax": true,
+    "verbatimModuleSyntax": false,
     "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",
@@ -19,7 +19,7 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "erasableSyntaxOnly": true,
+    "erasableSyntaxOnly": false,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -9,7 +9,7 @@
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
-    "verbatimModuleSyntax": true,
+    "verbatimModuleSyntax": false,
     "moduleDetection": "force",
     "noEmit": true,
 
@@ -17,7 +17,7 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "erasableSyntaxOnly": true,
+    "erasableSyntaxOnly": false,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },


### PR DESCRIPTION
## 実装内容
- react-router-domを利用してルーティング機能を追加
- 仮でサインアップ用の入力、確認、完了画面にそれぞれ遷移できることを確認
- ページが見つからない際の Not Found 画面とメンテナンス中の画面のルーティングを追加

## 備考
-  ルーティングは src\router に .tsx ファイルを追加し、router.ts ファイルでそれを取り込んで行う
- ページの配置は src\pages に機能ごとにまとめたディレクトリを追加し、その中に各ページの .tsx ファイルを格納する